### PR TITLE
Save CSS to file

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -75,7 +75,7 @@ class SiteOrigin_CSS {
 	/**
 	 * Display the custom CSS in the header.
 	 */
-	function action_wp_head(){
+	function action_wp_head() {
 		$upload_dir = wp_upload_dir();
 		$upload_dir_path = $upload_dir['basedir'] . '/so-css/';
 		
@@ -91,12 +91,12 @@ class SiteOrigin_CSS {
 			);
 		} else {
 			$custom_css = get_option( 'siteorigin_custom_css[' . $this->theme . ']', '' );
+			// We just need to enqueue a dummy style
 			if ( ! empty( $custom_css ) ) {
-                // We just need to enqueue a dummy style
-                echo "<style id='" . sanitize_html_class($this->theme) . "-custom-css' class='siteorigin-custom-css' type='text/css'>\n";
-                echo self::sanitize_css( $custom_css ) . "\n";
-                echo "</style>\n";
-		    }
+				echo "<style id='" . sanitize_html_class($this->theme) . "-custom-css' class='siteorigin-custom-css' type='text/css'>\n";
+				echo self::sanitize_css( $custom_css ) . "\n";
+				echo "</style>\n";
+			}
 		}
 	}
 
@@ -136,9 +136,9 @@ class SiteOrigin_CSS {
 				// Sort the revisions and cut off any old ones.
 				krsort($revisions);
 				$revisions = array_slice($revisions, 0, 15, true);
-
+				
 				update_option( 'siteorigin_custom_css_revisions[' . $this->theme . ']', $revisions );
-    
+				
 				if( WP_Filesystem() ) {
 					global $wp_filesystem;
 					$upload_dir = wp_upload_dir();
@@ -174,9 +174,9 @@ class SiteOrigin_CSS {
 			'id' => 'custom-css',
 			'title' => __( 'Custom CSS', 'so-css' ),
 			'content' => '<p>'
-	             . sprintf( __( "SiteOrigin CSS adds any custom CSS you enter here into your site's header. ", 'so-css' ) )
-	             . __( "These changes will persist across updates so it's best to make all your changes here. ", 'so-css' )
-	             . '</p>'
+				. sprintf( __( "SiteOrigin CSS adds any custom CSS you enter here into your site's header. ", 'so-css' ) )
+				. __( "These changes will persist across updates so it's best to make all your changes here. ", 'so-css' )
+				. '</p>'
 		) );
 	}
 
@@ -223,8 +223,8 @@ class SiteOrigin_CSS {
 
 		wp_localize_script( 'siteorigin-custom-css', 'socssOptions', array(
 			'themeCSS' => SiteOrigin_CSS::single()->get_theme_css(),
-            // Pretty confusing, but it seems we should be using `home_url` and NOT `site_url`
-            // as described here => https://wordpress.stackexchange.com/a/50605
+			// Pretty confusing, but it seems we should be using `home_url` and NOT `site_url`
+			// as described here => https://wordpress.stackexchange.com/a/50605
 			'homeURL' => add_query_arg( 'so_css_preview', '1', home_url() ),
 			'snippets' => $this->get_snippets(),
 

--- a/so-css.php
+++ b/so-css.php
@@ -45,7 +45,7 @@ class SiteOrigin_CSS {
 		// The request to hide the getting started video
 		add_action( 'wp_ajax_socss_hide_getting_started', array( $this, 'admin_action_hide_getting_started' ) );
 
-		if( isset($_GET['so_css_preview']) && !is_admin() ) {
+		if( isset( $_GET['so_css_preview'] ) && !is_admin() ) {
 
 			add_action( 'plugins_loaded', array($this, 'disable_ngg_resource_manager') );
 			add_filter( 'show_admin_bar', '__return_false' );
@@ -82,12 +82,12 @@ class SiteOrigin_CSS {
 		$css_file_name = 'so-css-' . $this->theme;
 		$css_file_path = $upload_dir_path . $css_file_name . '.css';
 		
-		if ( file_exists( $css_file_path ) ) {
+		if ( empty( $_GET['so_css_preview'] ) && ! is_admin() && file_exists( $css_file_path ) ) {
 			wp_enqueue_style(
 				'so-css-' . $this->theme,
 				set_url_scheme( $upload_dir['baseurl'] . '/so-css/' . $css_file_name . '.css' ),
 				array(),
-				SOCSS_VERSION
+				$this->get_latest_revision_timestamp()
 			);
 		} else {
 			$custom_css = get_option( 'siteorigin_custom_css[' . $this->theme . ']', '' );
@@ -476,6 +476,14 @@ class SiteOrigin_CSS {
 
 		//The NextGen Gallery plugin does some weird interfering with the output buffer.
 		define('NGG_DISABLE_RESOURCE_MANAGER', true);
+	}
+	
+	private function get_latest_revision_timestamp() {
+		$revisions = get_option( 'siteorigin_custom_css_revisions[' . $this->theme . ']' );
+		krsort( $revisions );
+		$revision_times = array_keys( $revisions );
+		
+		return $revision_times[0];
 	}
 }
 


### PR DESCRIPTION
To resolve #17. Simply stores the CSS as a file in uploads dir and uses the revision timestamp when enqueuing as an attempt at cache busting.