### PR TITLE
Fix timestamp notice on certan setups

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -480,6 +480,9 @@ class SiteOrigin_CSS {
 	
 	private function get_latest_revision_timestamp() {
 		$revisions = get_option( 'siteorigin_custom_css_revisions[' . $this->theme . ']' );
+		if( empty( $revisions) ) {
+			return false;
+		}
 		krsort( $revisions );
 		$revision_times = array_keys( $revisions );
 		


### PR DESCRIPTION
Resolves #69 
This issue will fix the following warnings:

(! ) Warning: krsort() expects parameter 1 to be array, boolean given in C:\wamp64\www\siteorigin\wp-content\plugins\so-css\so-css.php on line 485

( ! ) Warning: array_keys() expects parameter 1 to be array, boolean given in C:\wamp64\www\siteorigin\wp-content\plugins\so-css\so-css.php on line 486

Reported [here](https://siteorigin.com/thread/error-from-siteorigin-css/) and [here](https://siteorigin.com/thread/error-from-siteorigin-css-2). The issue was previously reported elsewhere but at the time it appeared to be user specific.