### PR TITLE
Reduced the Opacity field width

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -334,6 +334,10 @@
   border-radius: 0;
   font-size: 12px;
 }
+#so-custom-css-properties .sections .fields-table .socss-field-number input {
+  margin: 0;
+  width: 120px;
+}
 #so-custom-css-properties .sections .fields-table .minicolors input {
   box-sizing: border-box;
   height: 30px;
@@ -541,10 +545,6 @@
   text-align: right;
   padding: 10px 20px;
   overflow: hidden;
-}
-.socss-field-number input {
-  margin: 0;
-  width: 120px;
 }
 .socss-field-measurement {
   position: relative;

--- a/css/admin.css
+++ b/css/admin.css
@@ -542,6 +542,10 @@
   padding: 10px 20px;
   overflow: hidden;
 }
+.socss-field-number input {
+  margin: 0;
+  width: 120px;
+}
 .socss-field-measurement {
   position: relative;
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -662,6 +662,11 @@
 	}
 }
 
+.socss-field-number input {
+	margin: 0;
+	width: 120px;
+}
+
 .socss-field-measurement {
 
 	position: relative;

--- a/css/admin.less
+++ b/css/admin.less
@@ -398,6 +398,11 @@
 				font-size: 12px;
 			}
 
+			.socss-field-number input {
+				margin: 0;
+				width: 120px;
+			}
+
 			.minicolors input {
 				box-sizing: border-box;
 				height: 30px;
@@ -660,11 +665,6 @@
 
 
 	}
-}
-
-.socss-field-number input {
-	margin: 0;
-	width: 120px;
 }
 
 .socss-field-measurement {


### PR DESCRIPTION
Currently, if you select the Opacity field, you'll see the following:

![so-css](https://user-images.githubusercontent.com/789159/80867055-6375cd80-8c92-11ea-9337-43d7108ab1ec.png)

This PR reduces the width of the field in question. If there are further instances of this issue then we can perhaps look into a more holistic approach vs adding a single exception/override as I've done here.