### PR TITLE
Replace CSS Comment patterns with PHP 7.4 friendly patterns

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -676,11 +676,10 @@ class SiteOrigin_CSS {
 		
 		// Remove all CSS comments
 		$regex = array(
-			"`^([\t\s]+)`ism"                       => '',
-			"`^\/\*(.+?)\*\/`ism"                   => "",
-			"`([\n\A;]+)\/\*(.+?)\*\/`ism"          => "$1",
-			"`([\n\A;\s]+)//(.+?)[\n\r]`ism"        => "$1\n",
-			"`(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+`ism" => "\n"
+			"`^([\t\s]+)`ism"                             => '',
+			"`^\/\*(.+?)\*\/`ism"                         => "",
+			"`(\A|[\n;]+)/\*[^*]*\*+(?:[^/*][^*]*\*+)*/`" => "$1",
+			"`(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+`ism"       => "\n"
 		);
 		$css = preg_replace( array_keys( $regex ), $regex, $css );
 		$css = preg_replace( '/\s+/', ' ', $css );
@@ -724,13 +723,12 @@ class SiteOrigin_CSS {
 		if ( ! current_user_can( 'edit_theme_options' ) ) {
 			return;
 		}
-		
+
 		$regex = array(
-			"`^([\t\s]+)`ism"                       => '',
-			"`^\/\*(.+?)\*\/`ism"                   => "",
-			"`([\n\A;]+)\/\*(.+?)\*\/`ism"          => "$1",
-			"`([\n\A;\s]+)//(.+?)[\n\r]`ism"        => "$1\n",
-			"`(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+`ism" => "\n"
+			"`^([\t\s]+)`ism"                             => '',
+			"`^\/\*(.+?)\*\/`ism"                         => "",
+			"`(\A|[\n;]+)/\*[^*]*\*+(?:[^/*][^*]*\*+)*/`" => "$1",
+			"`(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+`ism"       => "\n"
 		);
 		
 		global $wp_styles;


### PR DESCRIPTION
The issue was linked to \A. That's valid but the regex library PHP is now using is apparently much stricter the rexex so the placement of the \A was now invalid due to it not being at the start.
https://stackoverflow.com/questions/57829977/error-when-removing-css-comments-via-regex

The regex that person is using is exactly the same as SiteOrigin CSS was using. It's from:
https://stackoverflow.com/questions/1581049/preg-replace-out-css-comments/1581063#1581063

I swapped out the now invalid regex with the ones suggested by that user:
`"`(\A|[\n;]+)/\*[^*]*\*+(?:[^/*][^*]*\*+)*/`"=>"$1"
`I tried the modified version on PHP 7.3, 7.2, and 7.1. It worked as expected - comments were still being spaced out.

Resolves https://github.com/siteorigin/so-css/issues/97.