### PR TITLE
Rename custom_css textarea to prevent conflicts

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -265,11 +265,11 @@ class SiteOrigin_CSS {
 			'display_admin_page'
 		) );
 
-		if ( current_user_can( 'edit_theme_options' ) && isset( $_POST['custom_css'] ) ) {
+		if ( current_user_can( 'edit_theme_options' ) && isset( $_POST['siteorigin_custom_css'] ) ) {
 			check_admin_referer( 'custom_css', '_sononce' );
 			
 			// Sanitize CSS input. Should keep most tags, apart from script and style tags.
-			$custom_css = self::sanitize_css( filter_input( INPUT_POST, 'custom_css' ) );
+			$custom_css = self::sanitize_css( filter_input( INPUT_POST, 'siteorigin_custom_css' ) );
 			$socss_post_id = filter_input( INPUT_GET, 'socss_post_id', FILTER_VALIDATE_INT );
 			
 			$current = $this->get_custom_css( $this->theme, $socss_post_id );

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -24,7 +24,7 @@ if ( ! empty( $current_revision ) ) {
 	</h2>
 
 
-	<?php if( isset($_POST['custom_css']) ) : ?>
+	<?php if( isset($_POST['siteorigin_custom_css']) ) : ?>
 		<div class="notice notice-success"><p><?php _e('Site design updated.', 'so-css') ?></p></div>
 	<?php endif; ?>
 
@@ -100,7 +100,7 @@ if ( ! empty( $current_revision ) ) {
 			</div>
 
 			<div class="custom-css-container">
-				<textarea name="custom_css" id="custom-css-textarea" class="css-editor" rows="<?php echo max( 10, substr_count( $custom_css, "\n" ) + 1 ) ?>"><?php echo esc_textarea( $custom_css ) ?></textarea>
+				<textarea name="siteorigin_custom_css" id="custom-css-textarea" class="css-editor" rows="<?php echo max( 10, substr_count( $custom_css, "\n" ) + 1 ) ?>"><?php echo esc_textarea( $custom_css ) ?></textarea>
 				<?php wp_nonce_field( 'custom_css', '_sononce' ) ?>
 			</div>
 			<p class="description"><?php esc_html_e( $editor_description ) ?></p>


### PR DESCRIPTION
This PR resolves https://github.com/siteorigin/so-css/issues/109.

I didn't realize that SiteOrigin CSS was saving when inside of the [admin_menu](https://developer.wordpress.org/reference/hooks/admin_menu/) hook. [This change](https://github.com/siteorigin/so-css/pull/108/commits/e43b01ad422f4a96b7c013e133789ba7cc035766#diff-1444ac476d5226ed00e47994a46e7a35R268) resulted in this issue as that would result in the `check_admin_referer` check triggering which will always fail outside of SiteOrigin CSS.

I checked SiteOrigin CSS saving is still working as expected and that the buttons plugin is saving without issue now. 