### PR TITLE
Updated button container class name

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -57,10 +57,10 @@
 #so-custom-css-info *:last-child {
   margin-bottom: 0;
 }
-#so-custom-css-info p.submit {
+#so-custom-css-info p.so-custom-css-submit {
   padding-top: 1px;
 }
-#so-custom-css-info p.submit .button-primary {
+#so-custom-css-info p.so-custom-css-submit .button-primary {
   font-size: 14px;
   min-height: 40px;
   width: 100%;

--- a/css/admin.less
+++ b/css/admin.less
@@ -75,7 +75,7 @@
 		margin-bottom: 0;
 	}
 
-	p.submit {
+	p.so-custom-css-submit {
 		padding-top: 1px;
 
 		.button-primary {

--- a/js/editor.js
+++ b/js/editor.js
@@ -373,7 +373,7 @@
 					$( '#siteorigin-custom-css' ).find( '> h2' ).outerHeight( true ) +
 					$form.find( '> .custom-css-toolbar' ).outerHeight( true ) +
 					$form.find( '> p.description' ).outerHeight( true ) +
-					$form.find( '> p.submit' ).outerHeight( true ) +
+					$form.find( '> p.so-custom-css-submit' ).outerHeight( true ) +
 					parseFloat( $( '#wpbody-content' ).css( 'padding-bottom' ) );
 				this.$el.find( '.CodeMirror-scroll' ).css( 'max-height', windowHeight - otherEltsHeight );
 				this.codeMirror.setSize( '100%', 'auto' );

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -36,7 +36,7 @@ if ( ! empty( $current_revision ) ) {
 
 	<div id="poststuff">
 		<div id="so-custom-css-info">
-			<p class="submit">
+			<p class="so-custom-css-submit">
 				<input type="submit" name="siteorigin_custom_css_save" class="button-primary" value="<?php esc_attr_e( $save_button_label ); ?>" />
 			</p>
 


### PR DESCRIPTION
This PR changes the paragraph class name that wraps the submit button. A user reported issues with the generic class name.

Ref: https://wordpress.org/support/topic/add-float-none-to-save-css-button/.