### PR TITLE
 Only show hints/autocomplete when showHint is available

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -340,20 +340,22 @@
 				}
 			}.bind( this ) );
 			
-			// This sets up automatic autocompletion at all times
-			this.codeMirror.on( 'keyup', function ( cm, e ) {
-				if (
-					( e.keyCode >= 65 && e.keyCode <= 90 ) ||
-					( e.keyCode === 189 && !e.shiftKey ) ||
-					( e.keyCode === 190 && !e.shiftKey ) ||
-					( e.keyCode === 51 && e.shiftKey ) ||
-					( e.keyCode === 189 && e.shiftKey )
-				) {
-					cm.showHint( {
-						completeSingle: false
-					} );
-				}
-			} );
+			if ( typeof CodeMirror.showHint == 'function' ) {
+				// This sets up automatic autocompletion at all times
+				this.codeMirror.on( 'keyup', function ( cm, e ) {
+					if (
+						( e.keyCode >= 65 && e.keyCode <= 90 ) ||
+						( e.keyCode === 189 && !e.shiftKey ) ||
+						( e.keyCode === 190 && !e.shiftKey ) ||
+						( e.keyCode === 51 && e.shiftKey ) ||
+						( e.keyCode === 189 && e.shiftKey )
+					) {
+						cm.showHint( {
+							completeSingle: false
+						} );
+					}
+				} );
+			}
 		},
 		
 		/**


### PR DESCRIPTION
This PR prevents a JavaScript error that occurs if a user dequeues `socss-codemirror-show-hint`. To test this comment [this line](https://github.com/siteorigin/so-css/blob/1.2.11/so-css.php#L326 out.

![2020-12-11_04-24-30-1379](https://user-images.githubusercontent.com/17275120/101813695-c7d20700-3b68-11eb-9621-3c0eb65bdffd.png)
