### PR TITLE
Resolve 5.6 scrollbar not being added

### DIFF
--- a/js/editor.js
+++ b/js/editor.js
@@ -373,9 +373,8 @@
 					$( '#siteorigin-custom-css' ).find( '> h2' ).outerHeight( true ) +
 					$form.find( '> .custom-css-toolbar' ).outerHeight( true ) +
 					$form.find( '> p.description' ).outerHeight( true ) +
-					$form.find( '> p.so-custom-css-submit' ).outerHeight( true ) +
 					parseFloat( $( '#wpbody-content' ).css( 'padding-bottom' ) );
-				this.$el.find( '.CodeMirror-scroll' ).css( 'max-height', windowHeight - otherEltsHeight );
+				this.$el.find( '.CodeMirror-scroll' ).css( 'max-height', windowHeight - otherEltsHeight + 'px' );
 				this.codeMirror.setSize( '100%', 'auto' );
 			}
 		},


### PR DESCRIPTION
This resulted in the scrollbar height never being set. In turn, the SiteOrigin CSS Editor is the full height rather than condensed. This used to fail gracefully with older versions of jQuery, but as of WordPress 5.6 (and the jQuery update), it doesn't anymore.