### PR TITLE
Always output local CodeMirror Theme styling

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -319,6 +319,7 @@ class SiteOrigin_CSS {
 		} else {
 			$this->enqueue_fallback_codemirror();
 		}
+		wp_enqueue_style( 'socss-codemirror-theme-neat', plugin_dir_url( __FILE__ ) . 'lib/codemirror/theme/neat.css', array(), '5.2.0' );
 
 		// Enqueue the scripts for theme CSS processing
 		wp_enqueue_script( 'siteorigin-css-parser-lib', plugin_dir_url( __FILE__ ) . 'js/css' . SOCSS_JS_SUFFIX . '.js', array( 'jquery' ), SOCSS_VERSION );
@@ -400,7 +401,6 @@ class SiteOrigin_CSS {
 
 		// All the CodeMirror styles
 		wp_enqueue_style( 'socss-codemirror', plugin_dir_url( __FILE__ ) . 'lib/codemirror/lib/codemirror.css', array(), '5.2.0' );
-		wp_enqueue_style( 'socss-codemirror-theme-neat', plugin_dir_url( __FILE__ ) . 'lib/codemirror/theme/neat.css', array(), '5.2.0' );
 		wp_enqueue_style( 'socss-codemirror-lint-css', plugin_dir_url( __FILE__ ) . 'lib/codemirror/addon/lint/lint.css', array(), '5.2.0' );
 		wp_enqueue_style( 'socss-codemirror-show-hint', plugin_dir_url( __FILE__ ) . 'lib/codemirror/addon/hint/show-hint.css', array(), '5.2.0' );
 		wp_enqueue_style( 'socss-codemirror-dialog', plugin_dir_url( __FILE__ ) . 'lib/codemirror/addon/dialog/dialog.css', '5.2.0' );


### PR DESCRIPTION
This PR will make SO CSS always load the CodeMirror theme we use regardless of whether we're using the WordPress or bundled version of CodeMirror.

Before:
![Screenshot_2021-01-08 Custom CSS ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/103928693-efb48a80-5167-11eb-90e6-51619d0456ce.png)

After:
![Screenshot_2021-01-08 Custom CSS ‹ SiteOrigin — WordPress(1)](https://user-images.githubusercontent.com/17275120/103928688-edeac700-5167-11eb-9361-7c5745fdd8b3.png)
