### PR TITLE
Resolve Photo Gallery Conflict

### DIFF
--- a/js/inspector.js
+++ b/js/inspector.js
@@ -72,7 +72,7 @@
             // Setup the click event
             var wcCheck = $( '.single-product' ).length;
             $('body *').on( 'click', function( e ) {
-                if( !thisView.active || thisView.$el.is(':hover') ) {
+                if ( ! thisView.active || thisView.$el[0] == e.target ) {
                     return true;
                 }
 


### PR DESCRIPTION
The [Photo Gallery](https://wordpress.org/plugins/photo-gallery/) plugin is having `.is( ':hover' ) (which isn't technically valid anymore) so this commit changes to a different method of confirming if the clicked item is the inspector or not.

To test this PR:
- Set up a basic Photo Gallery and add it to any page. (no setting adjustments are required) (this may not actually be required, but I wasn't able to replicate it until I had done this)
-  Open the expanded editor and try and navigate to a different page.