### PR TITLE
Toolbar Placement Adjustments

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -323,7 +323,7 @@
 #so-custom-css-properties .toolbar select {
   font-size: 13px;
   line-height: 28px;
-  max-width: 230px;
+  max-width: 220px;
   -webkit-transition: all 0.5s ease;
   -moz-transition: all 0.5s ease;
   -o-transition: all 0.5s ease;
@@ -712,7 +712,7 @@
   border: 1px solid #c0c0c0;
   color: #555;
   cursor: pointer;
-  float: left;
+  float: right;
   display: inline-block;
   font-size: 0.95em;
   font-weight: bold;

--- a/css/admin.less
+++ b/css/admin.less
@@ -408,7 +408,7 @@
 		select {
 			font-size: 13px;
 			line-height: 28px;
-			max-width: 230px;
+			max-width: 220px;
 			.transition(0.5s);
 
 			&.highlighted {
@@ -871,7 +871,7 @@
 	border: 1px solid #c0c0c0;
 	color: #555;
 	cursor: pointer;
-	float: left;
+	float: right;
 	display: inline-block;
 	font-size: 0.95em;
 	font-weight: bold;

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -87,18 +87,18 @@ if ( ! empty( $current_revision ) ) {
 				</div>
 
 				<div class="toolbar-action-buttons">
-					<span class="save socss-button button-primary">
-						<span class="so-css-icon so-css-icon-save"></span>
-					</span>
+					<a href="#expand" class="editor-expand socss-button">
+						<span class="so-css-icon so-css-icon-expand"></span>
+						<span class="so-css-icon so-css-icon-compress"></span>
+					</a>
 
 					<a href="#visual" class="editor-visual socss-button">
 						<span class="so-css-icon so-css-icon-eye"></span>
 					</a>
 
-					<a href="#expand" class="editor-expand socss-button">
-						<span class="so-css-icon so-css-icon-expand"></span>
-						<span class="so-css-icon so-css-icon-compress"></span>
-					</a>
+					<span class="save socss-button button-primary">
+						<span class="so-css-icon so-css-icon-save"></span>
+					</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
This PR moves the toolbar buttons over to the right in the expanded view, and ensures the save button is always the first button and the close mode button is always the last.

![Screenshot 2021-10-07 at 04-42-05 Custom CSS ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/136264158-3e82a0a0-76c4-4582-8494-cb4bc30f8019.png)
![Screenshot 2021-10-07 at 04-41-44 Custom CSS ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/136264172-ce8d3222-8f2a-48c0-aaf5-f9b7168c4adf.png)


