### PR TITLE
Resolve Active Link Detection Issue That Prevented Navigation

### DIFF
--- a/js/inspector.js
+++ b/js/inspector.js
@@ -72,7 +72,7 @@
             // Setup the click event
             var wcCheck = $( '.single-product' ).length;
             $('body *').on( 'click', function( e ) {
-                if ( ! thisView.active || thisView.$el[0] == e.target ) {
+                if ( ! thisView.active || $( e.target ).parent( '.socss-link' ).length ) {
                     return true;
                 }
 


### PR DESCRIPTION
This PR resolves the issue reported [here](https://wordpress.org/support/topic/navigate-to-the-page-in-question-does-not-work/). This issue wasn't introduced in https://github.com/siteorigin/so-css/pull/130 (as I can't replicate it while using that direct build) but the reasoning behind that PR is here as this PR supersedes it. This means that this PR must be tested against the Photo Gallery plugin to ensure compatibility.

To test this PR:
- Confirm that you're able to navigate to other pages and the general inspector works as expected.
- Run the tests outlined for https://github.com/siteorigin/so-css/pull/130 