### PR TITLE
Add Additional Save Button Below Editor

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -231,8 +231,8 @@
 }
 @media (max-width: 800px) {
   #so-custom-css-form .so-css-footer {
-    flex-direction: column-reverse;
     align-items: start;
+    flex-direction: column-reverse;
   }
 }
 #so-custom-css-form .decoration {

--- a/css/admin.css
+++ b/css/admin.css
@@ -223,6 +223,18 @@
   border-left: 1px solid #ddd;
   margin-left: 16px;
 }
+#so-custom-css-form .so-css-footer {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+@media (max-width: 800px) {
+  #so-custom-css-form .so-css-footer {
+    flex-direction: column-reverse;
+    align-items: start;
+  }
+}
 #so-custom-css-form .decoration {
   display: none;
 }

--- a/css/admin.less
+++ b/css/admin.less
@@ -293,6 +293,18 @@
 		}
 	}
 
+	.so-css-footer {
+		align-items: center;
+		display: flex;
+		justify-content: space-between;
+		margin-top: 10px;
+
+		@media (max-width: 800px) {
+			flex-direction: column-reverse;
+			align-items: start;
+		}
+	}
+
 	.decoration {
 		display: none;
 	}

--- a/css/admin.less
+++ b/css/admin.less
@@ -300,8 +300,8 @@
 		margin-top: 10px;
 
 		@media (max-width: 800px) {
-			flex-direction: column-reverse;
 			align-items: start;
+			flex-direction: column-reverse;
 		}
 	}
 

--- a/tpl/page.php
+++ b/tpl/page.php
@@ -106,7 +106,12 @@ if ( ! empty( $current_revision ) ) {
 				<textarea name="siteorigin_custom_css" id="custom-css-textarea" class="css-editor" rows="<?php echo max( 10, substr_count( $custom_css, "\n" ) + 1 ) ?>"><?php echo esc_textarea( $custom_css ) ?></textarea>
 				<?php wp_nonce_field( 'custom_css', '_sononce' ) ?>
 			</div>
-			<p class="description"><?php esc_html_e( $editor_description ) ?></p>
+			<div class="so-css-footer">
+				<input type="submit" name="siteorigin_custom_css_save" class="button-primary" value="<?php esc_attr_e( $save_button_label ); ?>" />
+				<p class="description">
+					<?php esc_html_e( $editor_description ); ?>
+				</p>
+			</div>
 
 			<div class="custom-css-preview">
 


### PR DESCRIPTION
This PR adds an additional save button below the editor. Its positioning is based on where the save button used to be.

![Screenshot 2021-11-10 at 10-49-01 Custom CSS ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/141029876-a4b59037-fc71-4cda-a925-e4b23f1a23b0.png)
![Screenshot 2021-11-10 at 10-52-18 Custom CSS ‹ SiteOrigin — WordPress](https://user-images.githubusercontent.com/17275120/141029887-8ab8803f-7eb4-41cb-a65d-e41c2c12d132.png)


