### PR TITLE
Correct Formatting in Teaser

### DIFF
--- a/tpl/page.php
+++ b/tpl/page.php
@@ -44,7 +44,7 @@ if ( ! empty( $current_revision ) ) {
 				<div class="postbox">
 					<h3 class="hndle"><span><?php esc_html_e( 'Get The Full Experience', 'so-css' ); ?></span></h3>
 					<div class="inside">
-						<?php printf( esc_html__( '%sSiteOrigin Premium%s adds a <strong>Google Web Font</strong> selector to SiteOrigin CSS so you can easily change any font.', 'so-css' ) , '<a href="https://siteorigin.com/downloads/premium/?featured_addon=plugin/web-font-selector" target="_blank">', '</a>' ); ?>
+						<?php printf( wp_kses_post( __( '%sSiteOrigin Premium%s adds a <strong>Google Web Font</strong> selector to SiteOrigin CSS so you can easily change any font.', 'so-css' ) ), '<a href="https://siteorigin.com/downloads/premium/?featured_addon=plugin/web-font-selector" target="_blank">', '</a>' ); ?>
 					</div>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
This PR resolves a formatting issue with a premium teaser:

![formatting-issue](https://user-images.githubusercontent.com/17275120/141689883-433d1275-4a90-4dbd-8aa6-dfb57e1894ea.png)

I've looked around and wasn't able to identify any other text affected by this issue.