### PR TITLE
Restore Scrollbar and Automatic Container Sizing Size

### DIFF
--- a/css/admin.css
+++ b/css/admin.css
@@ -206,7 +206,10 @@
   height: auto;
 }
 #so-custom-css-form .custom-css-container .CodeMirror-scroll {
+  margin: 0;
   min-height: 300px;
+  overflow-x: hidden !important;
+  padding: 0;
 }
 #so-custom-css-form .custom-css-container .CodeMirror-lines {
   padding: 8px 0 8px 0;

--- a/css/admin.less
+++ b/css/admin.less
@@ -272,7 +272,10 @@
 		}
 
 		.CodeMirror-scroll {
+			margin: 0;
 			min-height: 300px;
+			overflow-x: hidden !important; // important required due to CodeMirror styling.
+			padding: 0;
 		}
 
 		.CodeMirror-lines {

--- a/js/editor.js
+++ b/js/editor.js
@@ -398,10 +398,10 @@
 					areaHeight = 300;
 				}
 
-				this.$el.find( '.CodeMirror-scroll' ).css( 'min-height', areaHeight + 'px' );
 				this.codeMirror.setSize( '100%', 'auto' );
+				this.$el.find( '.CodeMirror-scroll' ).css( 'max-height', areaHeight + 'px' );
 			}
-			this.$el.find( '.CodeMirror-code' ).css( 'min-height', areaHeight + 'px' );
+			this.$el.find( '.CodeMirror-code' ).css( 'max-height', areaHeight + 'px' );
 		},
 		
 		/**

--- a/js/editor.js
+++ b/js/editor.js
@@ -389,7 +389,7 @@
 				var otherEltsHeight = $( '#wpadminbar' ).outerHeight( true ) +
 					$( '#siteorigin-custom-css' ).find( '> h2' ).outerHeight( true ) +
 					$form.find( '> .custom-css-toolbar' ).outerHeight( true ) +
-					$form.find( '> p.description' ).outerHeight( true ) +
+					$form.find( '> .so-css-footer' ).outerHeight( true ) +
 					parseFloat( $( '#wpbody-content' ).css( 'padding-bottom' ) );
 
 				areaHeight = windowHeight - otherEltsHeight;


### PR DESCRIPTION
This was broken due to a CodeMirror Library change in a recent WP update. :disappointed:  (unclear on the specific WP update)