### PR TITLE
Allow Custom CSS File Editing

### DIFF
--- a/so-css.php
+++ b/so-css.php
@@ -115,7 +115,7 @@ class SiteOrigin_CSS {
 				}
 				return $this->css_file;
 			} elseif ( ! empty( get_option( 'siteorigin_custom_file' ) ) ) {
-				// If the Custom file filter was previously active we need to
+				// If the custom file filter was previously active we need to
 				// generate the global CSS file to avoid no CSS outputting
 				// without modification.
 				delete_option( 'siteorigin_custom_file', true );

--- a/so-css.php
+++ b/so-css.php
@@ -91,6 +91,7 @@ class SiteOrigin_CSS {
 	function get_custom_css( $theme, $post_id = null ) {
 		$custom_css_file = apply_filters( 'siteorigin_custom_css_file', false );
 		if (
+			empty( $post_id ) &&
 			! empty( $custom_css_file ) &&
 			! empty( $custom_css_file['file'] ) &&
 			WP_Filesystem()
@@ -262,7 +263,6 @@ class SiteOrigin_CSS {
 	 *
 	 */
 	function enqueue_custom_css( $theme, $post_id = null ) {
-		add_filter( 'siteorigin_css_enqueue_css', '__return_false' );
 		$css_id = $theme . ( ! empty( $post_id ) ? '_' . $post_id : '' );
 		if (
 			empty( $_GET['so_css_preview'] ) &&

--- a/so-css.php
+++ b/so-css.php
@@ -95,10 +95,13 @@ class SiteOrigin_CSS {
 			// Did we previously load the CSS file? If not, load it.
 			if ( empty( $this->css_file ) || isset( $_POST['siteorigin_custom_css'] ) ) {
 				global $wp_filesystem;
-				if (
-					$wp_filesystem->exists( $custom_css_file ) &&
-					$wp_filesystem->is_writable( $custom_css_file )
-				) {
+
+				// If custom file doesn't exist, create it.
+				if ( ! $wp_filesystem->exists( $custom_css_file ) ) {
+					$wp_filesystem->touch( $custom_css_file );
+				}
+
+				if ( $wp_filesystem->is_writable( $custom_css_file ) ) {
 					$this->css_file = $wp_filesystem->get_contents( $custom_css_file );
 				}
 			}
@@ -153,7 +156,7 @@ class SiteOrigin_CSS {
 			$css_file_path = apply_filters( 'siteorigin_custom_css_file', false );
 
 			if (
-				empty( $this->css_file ) ||
+				empty( $css_file_path ) ||
 				! $wp_filesystem->is_writable( $css_file_path )
 			) {
 				$upload_dir = wp_upload_dir();
@@ -169,7 +172,7 @@ class SiteOrigin_CSS {
 				if ( file_exists( $css_file_path ) ) {
 					$wp_filesystem->delete( $css_file_path );
 				}
-			} else if ( ! $wp_filesystem->is_writable( $css_file_path ) ) {
+			} else {
 				$this->css_file = $custom_css;
 			}
 

--- a/so-css.php
+++ b/so-css.php
@@ -90,19 +90,23 @@ class SiteOrigin_CSS {
 	 */
 	function get_custom_css( $theme, $post_id = null ) {
 		$custom_css_file = apply_filters( 'siteorigin_custom_css_file', false );
-
-		if ( ! empty( $custom_css_file ) && WP_Filesystem() ) {
+		if (
+			! empty( $custom_css_file ) &&
+			! empty( $custom_css_file['file'] ) &&
+			WP_Filesystem()
+		) {
 			// Did we previously load the CSS file? If not, load it.
 			if ( empty( $this->css_file ) || isset( $_POST['siteorigin_custom_css'] ) ) {
 				global $wp_filesystem;
 
 				// If custom file doesn't exist, create it.
-				if ( ! $wp_filesystem->exists( $custom_css_file ) ) {
-					$wp_filesystem->touch( $custom_css_file );
+				if ( ! $wp_filesystem->exists( $custom_css_file['file'] ) ) {
+					$wp_filesystem->touch( $custom_css_file['file'] );
 				}
 
-				if ( $wp_filesystem->is_writable( $custom_css_file ) ) {
-					$this->css_file = $wp_filesystem->get_contents( $custom_css_file );
+
+				if ( $wp_filesystem->is_writable( $custom_css_file['file'] ) ) {
+					$this->css_file = $wp_filesystem->get_contents( $custom_css_file['file'] );
 				}
 			}
 			return $this->css_file;
@@ -157,7 +161,8 @@ class SiteOrigin_CSS {
 
 			if (
 				empty( $css_file_path ) ||
-				! $wp_filesystem->is_writable( $css_file_path )
+				empty( $css_file_path['file'] ) ||
+				! $wp_filesystem->is_writable( $css_file_path['file'] )
 			) {
 				$upload_dir = wp_upload_dir();
 				$upload_dir_path = $upload_dir['basedir'] . '/so-css/';
@@ -173,6 +178,7 @@ class SiteOrigin_CSS {
 					$wp_filesystem->delete( $css_file_path );
 				}
 			} else {
+				$css_file_path = $css_file_path['file'];
 				$this->css_file = $custom_css;
 			}
 

--- a/so-css.php
+++ b/so-css.php
@@ -256,26 +256,33 @@ class SiteOrigin_CSS {
 	 *
 	 */
 	function enqueue_custom_css( $theme, $post_id = null ) {
-		
-		$upload_dir = wp_upload_dir();
-		$upload_dir_path = $upload_dir['basedir'] . '/so-css/';
-		
+		add_filter( 'siteorigin_css_enqueue_css', '__return_false' );
 		$css_id = $theme . ( ! empty( $post_id ) ? '_' . $post_id : '' );
-		$css_file_name = 'so-css-' . $css_id;
-		$css_file_path = $upload_dir_path . $css_file_name . '.css';
-		
 		if (
 			empty( $_GET['so_css_preview'] ) &&
 			! is_admin() &&
-			file_exists( $css_file_path ) &&
 			apply_filters( 'siteorigin_css_enqueue_css', true )
 		) {
-			wp_enqueue_style(
-				'so-css-' . $css_id,
-				set_url_scheme( $upload_dir['baseurl'] . '/so-css/' . $css_file_name . '.css' ),
-				array(),
-				$this->get_latest_revision_timestamp()
-			);
+			$custom_css_file = apply_filters( 'siteorigin_custom_css_file', array() );
+			if ( ! empty( $post_id ) || empty( $custom_css_file ) ) {
+				$upload_dir = wp_upload_dir();
+				$upload_dir_path = $upload_dir['basedir'] . '/so-css/';
+				$css_file_name = 'so-css-' . $css_id;
+				$css_file_path = $upload_dir_path . $css_file_name . '.css';
+				$css_file_url = $upload_dir['baseurl'] . '/so-css/' . $css_file_name . '.css';
+			} elseif ( isset( $custom_css_file['url'] ) ) {
+				$css_file_path = $custom_css_file['file'];
+				$css_file_url = $custom_css_file['url'];
+			}
+			
+			if ( ! empty( $css_file_path ) && file_exists( $css_file_path ) ) {
+				wp_enqueue_style(
+					'so-css-' . $css_id,
+					set_url_scheme( $css_file_url ),
+					array(),
+					$this->get_latest_revision_timestamp()
+				);
+			}
 		} else {
 			$custom_css = $this->get_custom_css( $theme, $post_id );
 			// We just need to enqueue a dummy style


### PR DESCRIPTION
Resolves https://github.com/siteorigin/so-css/issues/160

This is done by introducing the `siteorigin_custom_css_file` filter which allows you to specify the URI for a custom CSS file (will be created if it doesn't exist) and URL for the file for SiteOrigin CSS to load - if the URL is empty, the developer will need to manually load the CSS file.

`siteorigin_custom_css_file` example::

```
add_filter( 'siteorigin_custom_css_file', function( $file ) {
	return array(
		'file' => get_template_directory() . '/rtl.css',
		'url' => get_template_directory_uri() . '/rtl.css',
	);
} );
```

(test using Vantage or any other theme that includes rtl.css)

This PR also introduces `siteorigin_css_enqueue_css` which controls whether SiteOrigin CSS will enqueue the custom CSS file. It can also be used by the user to force the CSS to output the CSS on the page directly if they would prefer.

`add_filter( 'siteorigin_css_enqueue_css', '__return_false' );`